### PR TITLE
Refactor templates a bit

### DIFF
--- a/app/Ohms/Interview.php
+++ b/app/Ohms/Interview.php
@@ -8,6 +8,7 @@
  * @license http://www.uky.edu
  */
 
+use Exception;
 use Ohms\Interview\Legacy;
 use Ohms\Interview\Version3;
 

--- a/app/Ohms/ViewerController.php
+++ b/app/Ohms/ViewerController.php
@@ -45,10 +45,10 @@ class ViewerController
                 $interview = $this->interview;
                 $interviewName = $this->interviewName;
                 $config = $this->config;
-				if($tmpl === 'viewer') {
-					include_once 'tmpl/viewer.tmpl.php';
+				if(file_exists('tmpl/' . $tmpl . '.tmpl.php')) {
+					include_once('tmpl/' . $tmpl . '.tmpl.php');
 				} else {
-					include_once 'tmpl/parts/' . $tmpl . '.tmpl.php';
+					throw new Exception("Cannot display template {$tmpl} - not found.");
 				}
                 break;
         }

--- a/app/Ohms/ViewerController.php
+++ b/app/Ohms/ViewerController.php
@@ -15,7 +15,7 @@ class ViewerController
         $this->interviewName = $interviewName;
     }
 
-    public function route($action, $kw, $interviewName)
+    public function route($action, $kw, $interviewName, $tmpl)
     {
         switch($action) {
             case 'metadata':
@@ -45,7 +45,11 @@ class ViewerController
                 $interview = $this->interview;
                 $interviewName = $this->interviewName;
                 $config = $this->config;
-                include_once 'tmpl/viewer.tmpl.php';
+				if($tmpl === 'viewer') {
+					include_once 'tmpl/viewer.tmpl.php';
+				} else {
+					include_once 'tmpl/parts/' . $tmpl . '.tmpl.php';
+				}
                 break;
         }
     }

--- a/app/Ohms/ViewerController.php
+++ b/app/Ohms/ViewerController.php
@@ -21,12 +21,10 @@ class ViewerController
             case 'metadata':
                 header('Content-type: application/json');
                 echo $this->interview->toJSON();
-                exit();
                 break;
             case 'xml':
                 header('Content-type: application/xml');
                 echo $this->interview->toXML();
-                exit();
                 break;
             case 'transcript':
                 echo $this->interview->getTranscript();
@@ -35,13 +33,11 @@ class ViewerController
                 if (isset($kw)) {
                     echo $this->interview->Transcript->keywordSearch($kw);
                 }
-                exit();
                 break;
             case 'index':
                 if (isset($kw)) {
                     echo $this->interview->Transcript->indexSearch($kw);
                 }
-                exit();
                 break;
             case 'all':
                 break;

--- a/app/init.php
+++ b/app/init.php
@@ -1,3 +1,0 @@
-<?php
-
-require_once __DIR__ . '/../vendor/autoload.php';

--- a/js/viewer_init.js
+++ b/js/viewer_init.js
@@ -1,0 +1,106 @@
+var jumpToTime = null;
+if (location.href.search('#segment') > -1) {
+	var jumpToTime = parseInt(location.href.replace(/(.*)#segment/i, ""));
+	if (isNaN(jumpToTime)) {
+		jumpToTime = 0;
+	}
+}
+
+$(document).ready(function() {
+
+	jQuery('a.indexSegmentLink').click(function (e) {
+		e.preventDefault();
+		var linkContainer = '#segmentLink' + jQuery(e.target).data('timestamp');
+		if (jQuery(linkContainer).css("display") == "none") {
+			jQuery(linkContainer).fadeIn(1000);
+		} else {
+			jQuery(linkContainer).fadeOut();
+		}
+	});
+
+	jQuery('.segmentLinkTextBox').on('click', function () {
+		jQuery(this).select();
+	});
+
+	if (jumpToTime !== null) {
+		jQuery('div.point').each(function (index) {
+			if (parseInt(jQuery(this).find('a.indexJumpLink').data('timestamp')) == jumpToTime) {
+				jumpLink = jQuery(this).find('a.indexJumpLink');
+				jQuery('#accordionHolder').accordion({active: index});
+				jQuery('#accordionHolder-alt').accordion({active: index});
+				var interval = setInterval(function() {
+					var reset = false;
+					switch(playerName) {
+						case 'youtube': 
+							if (player !== undefined && player.getCurrentTime !== undefined && player.getCurrentTime() == jumpToTime) {
+								reset = true;
+							}
+							break;
+						case 'brightcove': 
+							if (modVP !== undefined && modVP.getVideoPosition !== undefined && Math.floor(modVP.getVideoPosition(false)) == jumpToTime) {
+								reset = true;
+							}
+							break;
+						case 'kaltura': 
+							if (kdp !== undefined && kdp.evaluate('{video.player.currentTime}') == jumpToTime) {
+								reset = true;
+							}
+							break;
+						default: 
+							if (Math.floor(jQuery('#subjectPlayer').data('jPlayer').status.currentTime) == jumpToTime) {
+								reset = true;
+							}
+							break;
+					}
+					if(reset) {
+						clearInterval(interval);
+					} else {
+						jumpLink.click();
+					}
+				}, 500);
+
+				jQuery(this).find('a.indexJumpLink').click();
+			}
+		});
+	}
+
+	$(".fancybox").fancybox();
+	$(".various").fancybox({
+		maxWidth    : 800,
+		maxHeight   : 600,
+		fitToView   : false,
+		width       : '70%',
+		height      : '70%',
+		autoSize    : false,
+		closeClick  : false,
+		openEffect  : 'none',
+		closeEffect : 'none'
+	});
+	$('.fancybox-media').fancybox({
+		openEffect  : 'none',
+		closeEffect : 'none',
+		width       : '80%',
+		height      : '80%',
+		fitToView   : true,
+		helpers     : {
+			media : {}
+		}
+	});
+	$(".fancybox-button").fancybox({
+		prevEffect : 'none',
+		nextEffect : 'none',
+		closeBtn   : false,
+		helpers    : {
+			title   : { type : 'inside' },
+			buttons : {}
+		}
+	});
+	jQuery('#lnkRights').click(function() {
+	jQuery('#rightsStatement').fadeToggle(400);
+			return false;
+	});
+	jQuery('#lnkUsage').click(function() {
+		jQuery('#usageStatement').fadeToggle(400);
+		return false;
+	});
+});

--- a/render.php
+++ b/render.php
@@ -19,8 +19,9 @@ if (!isset($_REQUEST['cachefile']) || empty($_REQUEST['cachefile'])) {
 try {
 	$kw = (isset($_REQUEST['kw'])) ? $_REQUEST['kw'] : null;
 	$action = (isset($_REQUEST['action'])) ? $_REQUEST['action'] : null;
+	$tmpl = (isset($_REQUEST['view']) ? $_REQUEST['view'] : 'viewer');
 	$vController = new ViewerController($_REQUEST['cachefile']);
-	$vController->route($action, $kw, $_REQUEST['cachefile']);
+	$vController->route($action, $kw, $_REQUEST['cachefile'], $tmpl);
 } catch (Exception $e) {
 	header('Content-Type: text/plain', true, 500);
 	echo "Internal error.\n";

--- a/render.php
+++ b/render.php
@@ -2,7 +2,7 @@
 
 use Ohms\ViewerController;
 
-require_once 'app/init.php';
+require_once 'vendor/autoload.php';
 
 session_start();
 

--- a/render.php
+++ b/render.php
@@ -7,16 +7,23 @@ require_once 'vendor/autoload.php';
 session_start();
 
 if (!isset($_GET['translate'])) {
-    $_GET['translate'] = '0';
+	$_GET['translate'] = '0';
 }
 
-if (isset($_REQUEST['cachefile'])) {
-    $kw = (isset($_REQUEST['kw'])) ? $_REQUEST['kw'] : null;
-    $action = (isset($_REQUEST['action'])) ? $_REQUEST['action'] : null;
-    $vController = new ViewerController($_REQUEST['cachefile']);
-    $vController->route($action, $kw, $_REQUEST['cachefile']);
-} else {
-    header('HTTP/1.0 404 Not Found');
-    //echo 'Error no action to take.';
-    exit();
+if (!isset($_REQUEST['cachefile']) || empty($_REQUEST['cachefile'])) {
+	header('Content-Type: text/plain', true, 404);
+	echo "Invalid request: missing cache file parameter.\n";
+	exit();
+}
+
+try {
+	$kw = (isset($_REQUEST['kw'])) ? $_REQUEST['kw'] : null;
+	$action = (isset($_REQUEST['action'])) ? $_REQUEST['action'] : null;
+	$vController = new ViewerController($_REQUEST['cachefile']);
+	$vController->route($action, $kw, $_REQUEST['cachefile']);
+} catch (Exception $e) {
+	header('Content-Type: text/plain', true, 500);
+	echo "Internal error.\n";
+	echo "{$e->getCode()}: {$e->getMessage()}\n";
+	echo $e->getTraceAsString();
 }

--- a/tmpl/minimal.tmpl.php
+++ b/tmpl/minimal.tmpl.php
@@ -1,0 +1,4 @@
+<?php if (!isset($templateInitialized)) {
+	include 'init.tmpl.php';
+}?>
+<?php include 'parts/main.tmpl.php'; ?>

--- a/tmpl/parts/footer.tmpl.php
+++ b/tmpl/parts/footer.tmpl.php
@@ -1,0 +1,34 @@
+<div id="footer">
+	<div id="footer-metadata">
+		<?php if (!empty($rights)) { ?>
+			<h3><a href="#" id="lnkRights">View Rights Statement</a></h3>
+			<div id="rightsStatement"><p><?php echo $rights; ?></p></div>
+		<?php } else { ?>
+			<h3>No Rights Statement</h3>
+		<?php }	?>
+
+		<?php if (!empty($usage)) { ?>
+			<h3><a href="#" id="lnkUsage">View Usage Statement</a></h3>
+			<div id="usageStatement"><p><?php echo $usage; ?></p></div>
+		<?php } else { ?>
+			<h3>No Usage Statement</h3>
+		<?php }	?>
+
+		<?php if (!empty($collectionLink)) { ?>
+			<h3>Collection Link: <a	href="<?php echo $interview->collection_link ?>"><?php echo $interview->collection ?></a></h3>
+		<?php }	?>
+
+		<?php if (!empty($seriesLink)) { ?>
+			<h3>Series Link: <a href="<?php echo $interview->series_link ?>"><?php echo $interview->series ?></a></h3>
+		<?php }	?>
+
+		<h3>Contact Us: <a href="mailto:<?php echo $contactemail ?>"><?php echo $contactemail ?></a> | <a href="<?php echo $contactlink ?>"><?php echo $contactlink ?></a></h3>
+	</div>
+	<div id="footer-copyright">
+		<small id="copyright">&copy; <?php echo Date("Y") ?> <?php echo $copyrightholder ?></small>
+	</div>
+	<div id="footer-logo">
+		<img alt="Powered by OHMS logo" src="imgs/ohms_logo.png" border="0"/>
+	</div>
+	<br clear="both" />
+</div>

--- a/tmpl/parts/ga.tmpl.php
+++ b/tmpl/parts/ga.tmpl.php
@@ -1,0 +1,17 @@
+<?php if (isset($repoConfig['ga_tracking_id']) && $repoConfig['ga_tracking_id'] !== ''): ?>
+	<script type="text/javascript">
+		(function (i, s, o, g, r, a, m) {
+			i['GoogleAnalyticsObject'] = r;
+			i[r] = i[r] || function () {
+				(i[r].q = i[r].q || []).push(arguments)
+			}, i[r].l = 1 * new Date();
+			a = s.createElement(o),
+					m = s.getElementsByTagName(o)[0];
+			a.async = 1;
+			a.src = g;
+			m.parentNode.insertBefore(a, m)
+		})(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+		ga('create', '<?php echo $repoConfig['ga_tracking_id']; ?>', '<?php echo $repoConfig['ga_host']; ?>');
+		ga('send', 'pageview');
+	</script>
+<?php endif; ?>

--- a/tmpl/parts/init.tmpl.php
+++ b/tmpl/parts/init.tmpl.php
@@ -1,0 +1,40 @@
+<?php
+date_default_timezone_set($config['timezone']);
+$audioFormats = array('.mp3', '.wav', '.ogg', '.flac', '.m4a');
+$filepath = $interview->media_url;
+$rights = (string) $interview->rights;
+$usage = (string) $interview->usage;
+$contactemail = '';
+$contactlink = '';
+$copyrightholder = '';
+$protocol = 'https';
+if (!isset($_SERVER['HTTPS']) || $_SERVER['HTTPS'] != 'on') {
+	$protocol = 'http';
+}
+$host = $_SERVER['HTTP_HOST'];
+$uri = $_SERVER['REQUEST_URI'];
+$baseurl = "$protocol://$host$uri";
+$extraCss = null;
+if (isset($config[$interview->repository])) {
+	$repoConfig = $config[$interview->repository];
+	$contactemail = $repoConfig['contactemail'];
+	$contactlink = $repoConfig['contactlink'];
+	$copyrightholder = $repoConfig['copyrightholder'];
+	if (isset($repoConfig['open_graph_image']) && $repoConfig['open_graph_image'] <> '') {
+		$openGraphImage = $repoConfig['open_graph_image'];
+	}
+	if (isset($repoConfig['open_graph_description']) && $repoConfig['open_graph_description'] <> '') {
+		$openGraphDescription = $repoConfig['open_graph_description'];
+	}
+
+	if (isset($repoConfig['css']) && strlen($repoConfig['css']) > 0) {
+		$extraCss = $repoConfig['css'];
+	}
+}
+$seriesLink = (string) $interview->series_link;
+$collectionLink = (string) $interview->collection_link;
+$lang = (string) $interview->translate;
+
+$templateInitialized = true;
+
+?>

--- a/tmpl/parts/main.tmpl.php
+++ b/tmpl/parts/main.tmpl.php
@@ -1,0 +1,48 @@
+<?php if (!isset($templateInitialized)) {
+	include 'init.tmpl.php';
+}?>
+
+<?php $class = in_array(substr(strtolower($filepath), -4, 4), $audioFormats) ? "header" : "headervid"; ?>
+<div id="<?php echo $class; ?>">				
+	<?php if (isset($config[$interview->repository])): ?>
+		<img id="headerimg" src="<?php echo $config[$interview->repository]['footerimg']; ?>" alt="<?php echo $config[$interview->repository]['footerimgalt']; ?>" />
+	<?php endif; ?>
+	<div class="center">
+		<h1><?php echo $interview->title; ?></h1>
+		<h2 id="secondaryMetaData">
+			<div>
+				<strong><?php echo $interview->repository; ?></strong><br />
+				<?php echo $interview->interviewer; ?>, Interviewer | <?php echo $interview->accession; ?><br />
+				<?php if (isset($interview->collection_link) && (string) $interview->collection_link != '') { ?>
+					<a href="<?php echo $interview->collection_link ?>"><?php echo $interview->collection ?></a> |
+				<?php } else { ?>
+					<?php echo $interview->collection; ?> |
+				<?php } ?>
+
+				<?php if (isset($interview->series_link) && (string) $interview->series_link != '') { ?>
+					<a href="<?php echo $interview->series_link ?>"><?php echo $interview->series ?></a>
+				<?php } else { ?>
+					<?php echo $interview->series; ?>
+				<?php } ?>
+			</div>
+		</h2>
+		<div id="audio-panel">
+			<?php include_once 'tmpl/player_' . $interview->playername . '.tmpl.php'; ?>
+		</div>
+	</div>			
+</div>
+
+<div id="main">
+	<div id="main-panels">
+		<div id="content-panel">
+			<div id="holder-panel"></div>
+			<div id="transcript-panel" class="transcript-panel">
+				<?php echo $interview->transcript; ?>
+			</div>
+			<div id="index-panel" class="index-panel">
+				<?php echo $interview->index; ?>
+			</div>
+		</div>
+		<div id="searchbox-panel"><?php include_once 'tmpl/search.tmpl.php'; ?></div>
+	</div>
+</div>

--- a/tmpl/parts/main.tmpl.php
+++ b/tmpl/parts/main.tmpl.php
@@ -1,7 +1,3 @@
-<?php if (!isset($templateInitialized)) {
-	include 'init.tmpl.php';
-}?>
-
 <?php $class = in_array(substr(strtolower($filepath), -4, 4), $audioFormats) ? "header" : "headervid"; ?>
 <div id="<?php echo $class; ?>">				
 	<?php if (isset($config[$interview->repository])): ?>

--- a/tmpl/parts/og.tmpl.php
+++ b/tmpl/parts/og.tmpl.php
@@ -1,0 +1,22 @@
+<?php
+
+if (isset($config[$interview->repository])) {
+	$repoConfig = $config[$interview->repository];
+	if (isset($repoConfig['open_graph_image']) && $repoConfig['open_graph_image'] !== '') {
+		$openGraphImage = $repoConfig['open_graph_image'];
+	}
+	if (isset($repoConfig['open_graph_description']) && $repoConfig['open_graph_description'] !== '') {
+		$openGraphDescription = $repoConfig['open_graph_description'];
+	}
+}
+?>
+
+<meta property="og:title" content="<?php echo $interview->title; ?>" />
+<meta property="og:url" content="<?php echo $baseurl ?>">
+
+<?php if (isset($openGraphImage)): ?>
+	<meta property="og:image" content="<?php echo "$baseurl/$openGraphImage" ?>">
+<?php endif; ?>
+<?php if (isset($openGraphDescription)): ?>
+	<meta property="og:description" content="<?php echo "$openGraphDescription" ?>">
+<?php endif; ?>

--- a/tmpl/viewer.tmpl.php
+++ b/tmpl/viewer.tmpl.php
@@ -299,8 +299,6 @@ switch ($interview->playername) {
 <script type="text/javascript">
 var cachefile = '<?php echo $interview->cachefile; ?>';
 </script>
-<?php if (isset($gaScript)) {
-    echo $gaScript;
-} ?>
+<?php include 'parts/ga.tmpl.php'; ?>
   </body>
 </html>

--- a/tmpl/viewer.tmpl.php
+++ b/tmpl/viewer.tmpl.php
@@ -1,278 +1,262 @@
 <?php
 date_default_timezone_set($config['timezone']);
 $audioFormats = array('.mp3', '.wav', '.ogg', '.flac', '.m4a');
-$filepath =$interview->media_url;
-$rights = (string)$interview->rights;
-$usage = (string)$interview->usage;
+$filepath = $interview->media_url;
+$rights = (string) $interview->rights;
+$usage = (string) $interview->usage;
 $contactemail = '';
 $contactlink = '';
 $copyrightholder = '';
 $protocol = 'https';
 if (!isset($_SERVER['HTTPS']) || $_SERVER['HTTPS'] != 'on') {
-    $protocol = 'http';
+	$protocol = 'http';
 }
 $host = $_SERVER['HTTP_HOST'];
 $uri = $_SERVER['REQUEST_URI'];
 $baseurl = "$protocol://$host$uri";
 $extraCss = null;
 if (isset($config[$interview->repository])) {
-    $repoConfig = $config[$interview->repository];
-    $contactemail = $repoConfig['contactemail'];
-    $contactlink = $repoConfig['contactlink'];
-    $copyrightholder = $repoConfig['copyrightholder'];
-    if (isset($repoConfig['open_graph_image']) && $repoConfig['open_graph_image'] <> '') {
-        $openGraphImage = $repoConfig['open_graph_image'];
-    }
-    if (isset($repoConfig['open_graph_description']) && $repoConfig['open_graph_description'] <> '') {
-        $openGraphDescription = $repoConfig['open_graph_description'];
-    }
+	$repoConfig = $config[$interview->repository];
+	$contactemail = $repoConfig['contactemail'];
+	$contactlink = $repoConfig['contactlink'];
+	$copyrightholder = $repoConfig['copyrightholder'];
+	if (isset($repoConfig['open_graph_image']) && $repoConfig['open_graph_image'] <> '') {
+		$openGraphImage = $repoConfig['open_graph_image'];
+	}
+	if (isset($repoConfig['open_graph_description']) && $repoConfig['open_graph_description'] <> '') {
+		$openGraphDescription = $repoConfig['open_graph_description'];
+	}
 
-    if (isset($repoConfig['css']) && strlen($repoConfig['css']) > 0) {
-        $extraCss = $repoConfig['css'];
-    }
+	if (isset($repoConfig['css']) && strlen($repoConfig['css']) > 0) {
+		$extraCss = $repoConfig['css'];
+	}
 }
-$seriesLink = (string)$interview->series_link;
-$collectionLink = (string)$interview->collection_link;
-$lang = (string)$interview->translate;
+$seriesLink = (string) $interview->series_link;
+$collectionLink = (string) $interview->collection_link;
+$lang = (string) $interview->translate;
 ?>
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
-    <title><?php echo $interview->title; ?></title>
-    <link rel="stylesheet" href="css/viewer.css" type="text/css" />
-    <?php if (isset($extraCss)) { ?>
-    <link rel="stylesheet" href="css/<?php echo $extraCss ?>" type="text/css" />
-    <?php
-} ?>
-    <link rel="stylesheet" href="css/jquery-ui.toggleSwitch.css" type="text/css" />
-    <link rel="stylesheet" href="css/jquery-ui-1.8.16.custom.css" type="text/css" />
-    <link rel="stylesheet" href="css/font-awesome.css">
-    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
-    <script type="text/javascript" src="js/jquery-ui.toggleSwitch.js"></script>
-    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js"></script>
-    <script type="text/javascript" src="js/viewer.js"></script>
-	<script type="text/javascript" src="js/jquery.jplayer.min.js"></script>
-	<script type="text/javascript" src="js/jquery.easing.1.3.js"></script>
-	<script type="text/javascript" src="js/jquery.scrollTo-min.js"></script>
-	<script type="text/javascript" src="js/viewer_<?php echo  $interview->viewerjs;?>.js"></script>
-	<link rel="stylesheet" href="js/fancybox_2_1_5/source/jquery.fancybox.css?v=2.1.5" type="text/css" media="screen" />
-	<link rel="stylesheet" href="skin/jplayer.blue.monday.css" type="text/css" media="screen" />
-	<script type="text/javascript" src="js/fancybox_2_1_5/source/jquery.fancybox.pack.js?v=2.1.5"></script>
-	<link rel="stylesheet" href="js/fancybox_2_1_5/source/helpers/jquery.fancybox-buttons.css?v=1.0.5" type="text/css" media="screen" />
-	<script type="text/javascript" src="js/fancybox_2_1_5/source/helpers/jquery.fancybox-buttons.js?v=1.0.5"></script>
-	<script type="text/javascript" src="js/fancybox_2_1_5/source/helpers/jquery.fancybox-media.js?v=1.0.6"></script>
-	<link rel="stylesheet" href="js/fancybox_2_1_5/source/helpers/jquery.fancybox-thumbs.css?v=1.0.7" type="text/css" media="screen" />
-	<script type="text/javascript" src="js/fancybox_2_1_5/source/helpers/jquery.fancybox-thumbs.js?v=1.0.7"></script>
-	<?php include 'parts/og.tmpl.php'; ?>
-  </head>
-  <body>
-<script type="text/javascript">
-var jumpToTime = null;
-if (location.href.search('#segment') > -1) {
-  var jumpToTime = parseInt(location.href.replace(/(.*)#segment/i, ""));
-  if (isNaN(jumpToTime)) {
-    jumpToTime = 0;
-  }
-}
-</script>
-<?php if (in_array(substr(strtolower($filepath), -4, 4), $audioFormats)) { ?>
-    <div id="header">
-    <?php
-} else { ?>
-    <div id="headervid">
-    <?php
-} ?>
-        <?php if(isset($config[$interview->repository])): ?>
-        <img id="headerimg"
-             src="<?php echo $config[$interview->repository]['footerimg'];?>"
-             alt="<?php echo $config[$interview->repository]['footerimgalt'];?>" />
-        <?php
-endif; ?>
-    <div class="center">
-      <h1><?php echo $interview->title; ?></h1>
-      <h2 id="secondaryMetaData">
-        <div>
-          <strong><?php echo $interview->repository; ?></strong><br />
-          <?php echo $interview->interviewer; ?>, Interviewer |
-          <?php echo $interview->accession; ?><br />
-          <?php if (isset($interview->collection_link) && (string)$interview->collection_link != '') { ?>
-          <a href="<?php echo $interview->collection_link?>"><?php echo $interview->collection?></a> |
-          <?php
-} else { ?>
-          <?php echo $interview->collection; ?> |
-          <?php
-} ?>
-          <?php if (isset($interview->series_link) && (string)$interview->series_link != '') { ?>
-          <a href="<?php echo $interview->series_link?>"><?php echo $interview->series?></a>
-          <?php
-} else { ?>
-          <?php echo $interview->series; ?>
-          <?php
-} ?>
-        </div>
-      </h2>
-      <div id="audio-panel">
-        <?php include_once 'tmpl/player_'.$interview->playername.'.tmpl.php'; ?>
-      </div>
-    </div>
-    </div>
-    <div id="main">
-      <div id="main-panels">
-    <div id="content-panel">
-      <div id="holder-panel"></div>
-      <div id="transcript-panel" class="transcript-panel">
-        <?php echo $interview->transcript; ?>
-      </div>
-      <div id="index-panel" class="index-panel">
-        <?php echo $interview->index; ?>
-      </div>
-    </div>
-    <div id="searchbox-panel"><?php include_once 'tmpl/search.tmpl.php'; ?></div>
-    </div>
-    </div>
-    <div id="footer">
-      <div id="footer-metadata">
-        <?php if (!empty($rights)) { ?>
-        <p><span><h3><a href="#" id="lnkRights">View Rights Statement</a></h3>
-        <div id="rightsStatement"><?php echo $rights; ?></div></span></p>
-        <?php
-} else { ?>
-        <p><span><h3>View Rights Statement</h3></span></p>
-        <?php
-} ?>
-        <?php if (!empty($usage)) { ?>
-        <p><span><h3><a href="#" id="lnkUsage">View Usage Statement</a></h3>
-        <div id="usageStatement"><?php echo $usage; ?></div></span></p>
-        <?php
-} else { ?>
-        <p><span><h3>View Usage Statement</h3></span></p>
-        <?php
-} ?>
-        <?php if (!empty($collectionLink)) { ?>
-        <p><span><h3>Collection Link: <a
-          href="<?php echo $interview->collection_link?>"><?php echo $interview->collection?></a></h3></span></p>
-        <?php
-} ?>
-        <?php if (!empty($seriesLink)) { ?>
-        <p><span><h3>Series Link: <a
-          href="<?php echo $interview->series_link?>"><?php echo $interview->series?></a></h3></span></p>
-        <?php
-} ?>
-        <p><span><h3>Contact Us: <a href="mailto:<?php echo $contactemail ?>"><?php echo $contactemail ?></a> |
-        <a href="<?php echo $contactlink ?>"><?php echo $contactlink ?></a></h3></span></p>
-        </div>
-        <div id="footer-copyright">
-          <small id="copyright"><span>&copy; <?php echo Date("Y") ?></span><?php echo $copyrightholder ?></small>
-        </div>
-        <div id="footer-logo">
-          <img alt="Powered by OHMS logo" src="imgs/ohms_logo.png" border="0"/>
-        </div>
-        <br clear="both" />
-      </div>
-<script type="text/javascript">
-$(document).ready(function() {
-  jQuery('a.indexSegmentLink').on('click', function (e) {
-    var linkContainer = '#segmentLink' + jQuery(e.target).data('timestamp');
-    e.preventDefault();
-    if (jQuery(linkContainer).css("display") == "none") {
-      jQuery(linkContainer).fadeIn(1000);
-    } else {
-      jQuery(linkContainer).fadeOut();
-    }
+	<head>
+		<meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+		<title><?php echo $interview->title; ?></title>
+		<link rel="stylesheet" href="css/viewer.css" type="text/css" />
+		<?php if (isset($extraCss)) { ?>
+			<link rel="stylesheet" href="css/<?php echo $extraCss ?>" type="text/css" />
+		<?php } ?>
+		<link rel="stylesheet" href="css/jquery-ui.toggleSwitch.css" type="text/css" />
+		<link rel="stylesheet" href="css/jquery-ui-1.8.16.custom.css" type="text/css" />
+		<link rel="stylesheet" href="css/font-awesome.css">
+		<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+		<script type="text/javascript" src="js/jquery-ui.toggleSwitch.js"></script>
+		<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js"></script>
+		<script type="text/javascript" src="js/viewer.js"></script>
+		<script type="text/javascript" src="js/jquery.jplayer.min.js"></script>
+		<script type="text/javascript" src="js/jquery.easing.1.3.js"></script>
+		<script type="text/javascript" src="js/jquery.scrollTo-min.js"></script>
+		<script type="text/javascript" src="js/viewer_<?php echo $interview->viewerjs; ?>.js"></script>
+		<link rel="stylesheet" href="js/fancybox_2_1_5/source/jquery.fancybox.css?v=2.1.5" type="text/css" media="screen" />
+		<link rel="stylesheet" href="skin/jplayer.blue.monday.css" type="text/css" media="screen" />
+		<script type="text/javascript" src="js/fancybox_2_1_5/source/jquery.fancybox.pack.js?v=2.1.5"></script>
+		<link rel="stylesheet" href="js/fancybox_2_1_5/source/helpers/jquery.fancybox-buttons.css?v=1.0.5" type="text/css" media="screen" />
+		<script type="text/javascript" src="js/fancybox_2_1_5/source/helpers/jquery.fancybox-buttons.js?v=1.0.5"></script>
+		<script type="text/javascript" src="js/fancybox_2_1_5/source/helpers/jquery.fancybox-media.js?v=1.0.6"></script>
+		<link rel="stylesheet" href="js/fancybox_2_1_5/source/helpers/jquery.fancybox-thumbs.css?v=1.0.7" type="text/css" media="screen" />
+		<script type="text/javascript" src="js/fancybox_2_1_5/source/helpers/jquery.fancybox-thumbs.js?v=1.0.7"></script>
+		<?php include 'parts/og.tmpl.php'; ?>
+	</head>
+	<body>
+		<?php if (in_array(substr(strtolower($filepath), -4, 4), $audioFormats)) { ?>
+			<div id="header">
+			<?php } else { ?>
+				<div id="headervid">
+				<?php } ?>
+				<?php if (isset($config[$interview->repository])): ?>
+					<img id="headerimg"
+						 src="<?php echo $config[$interview->repository]['footerimg']; ?>"
+						 alt="<?php echo $config[$interview->repository]['footerimgalt']; ?>" />
+						 <?php endif;
+					 ?>
+				<div class="center">
+					<h1><?php echo $interview->title; ?></h1>
+					<h2 id="secondaryMetaData">
+						<div>
+							<strong><?php echo $interview->repository; ?></strong><br />
+							<?php echo $interview->interviewer; ?>, Interviewer |
+							<?php echo $interview->accession; ?><br />
+							<?php if (isset($interview->collection_link) && (string) $interview->collection_link != '') { ?>
+								<a href="<?php echo $interview->collection_link ?>"><?php echo $interview->collection ?></a> |
+								<?php } else { ?>
+								<?php echo $interview->collection; ?> |
+								<?php } ?>
+							<?php if (isset($interview->series_link) && (string) $interview->series_link != '') { ?>
+								<a href="<?php echo $interview->series_link ?>"><?php echo $interview->series ?></a>
+								<?php } else { ?>
+								<?php echo $interview->series; ?>
+								<?php } ?>
+						</div>
+					</h2>
+					<div id="audio-panel">
+						<?php include_once 'tmpl/player_' . $interview->playername . '.tmpl.php'; ?>
+					</div>
+				</div>
+			</div>
+			<div id="main">
+				<div id="main-panels">
+					<div id="content-panel">
+						<div id="holder-panel"></div>
+						<div id="transcript-panel" class="transcript-panel">
+							<?php echo $interview->transcript; ?>
+						</div>
+						<div id="index-panel" class="index-panel">
+							<?php echo $interview->index; ?>
+						</div>
+					</div>
+					<div id="searchbox-panel"><?php include_once 'tmpl/search.tmpl.php'; ?></div>
+				</div>
+			</div>
+			<div id="footer">
+				<div id="footer-metadata">
+					<?php if (!empty($rights)) { ?>
+						<p><span><h3><a href="#" id="lnkRights">View Rights Statement</a></h3>
+								<div id="rightsStatement"><?php echo $rights; ?></div></span></p>
+						<?php } else { ?>
+						<p><span><h3>View Rights Statement</h3></span></p>
+						<?php }	?>
+					<?php if (!empty($usage)) { ?>
+						<p><span><h3><a href="#" id="lnkUsage">View Usage Statement</a></h3>
+								<div id="usageStatement"><?php echo $usage; ?></div></span></p>
+						<?php } else { ?>
+						<p><span><h3>View Usage Statement</h3></span></p>
+						<?php }	?>
+					<?php if (!empty($collectionLink)) { ?>
+						<p><span><h3> Collection Link: <a	href="<?php echo $interview->collection_link ?>"><?php echo $interview->collection ?></a></h3></span></p>
+							<?php }	?>
+						<?php if (!empty($seriesLink)) { ?>
+						<p><span><h3>Series Link: <a href="<?php echo $interview->series_link ?>"><?php echo $interview->series ?></a></h3></span></p>
+							<?php }	?>
+					<p><span><h3>Contact Us: <a href="mailto:<?php echo $contactemail ?>"><?php echo $contactemail ?></a> |
+								<a href="<?php echo $contactlink ?>"><?php echo $contactlink ?></a></h3></span></p>
+				</div>
+				<div id="footer-copyright">
+					<small id="copyright"><span>&copy; <?php echo Date("Y") ?></span><?php echo $copyrightholder ?></small>
+				</div>
+				<div id="footer-logo">
+					<img alt="Powered by OHMS logo" src="imgs/ohms_logo.png" border="0"/>
+				</div>
+				<br clear="both" />
+			</div>
+			<script type="text/javascript">				
+				var cachefile = '<?php echo $interview->cachefile; ?>';
+				var playerName = '<?php echo $interview->playername; ?>';
+				console.log(playerName);
+				var jumpToTime = null;
+				if (location.href.search('#segment') > -1) {
+					var jumpToTime = parseInt(location.href.replace(/(.*)#segment/i, ""));
+					if (isNaN(jumpToTime)) {
+						jumpToTime = 0;
+					}
+				}
+				
+				$(document).ready(function() {
 
-    return false;
-  });
+					jQuery('a.indexSegmentLink').click(function (e) {
+						e.preventDefault();
+						var linkContainer = '#segmentLink' + jQuery(e.target).data('timestamp');
+						if (jQuery(linkContainer).css("display") == "none") {
+							jQuery(linkContainer).fadeIn(1000);
+						} else {
+							jQuery(linkContainer).fadeOut();
+						}
+					});
+					
+					jQuery('.segmentLinkTextBox').on('click', function () {
+						jQuery(this).select();
+					});
+					
+					if (jumpToTime !== null) {
+						jQuery('div.point').each(function (index) {
+							if (parseInt(jQuery(this).find('a.indexJumpLink').data('timestamp')) == jumpToTime) {
+								jumpLink = jQuery(this).find('a.indexJumpLink');
+								jQuery('#accordionHolder').accordion({active: index});
+								jQuery('#accordionHolder-alt').accordion({active: index});
+								var interval = setInterval(function() {
+									var reset = false;
+									switch(playerName) {
+										case 'youtube': 
+											if (player !== undefined && player.getCurrentTime !== undefined && player.getCurrentTime() == jumpToTime) {
+												reset = true;
+											}
+											break;
+										case 'brightcove': 
+											if (modVP !== undefined && modVP.getVideoPosition !== undefined && Math.floor(modVP.getVideoPosition(false)) == jumpToTime) {
+												reset = true;
+											}
+											break;
+										case 'kaltura': 
+											if (kdp !== undefined && kdp.evaluate('{video.player.currentTime}') == jumpToTime) {
+												reset = true;
+											}
+											break;
+										default: 
+											if (Math.floor(jQuery('#subjectPlayer').data('jPlayer').status.currentTime) == jumpToTime) {
+												reset = true;
+											}
+											break;
+									}
+									if(reset) {
+										clearInterval(interval);
+									} else {
+										jumpLink.click();
+									}
+								}, 500);
+								
+								jQuery(this).find('a.indexJumpLink').click();
+							}
+						});
+					}
 
-  jQuery('.segmentLinkTextBox').on('click', function () {
-    jQuery(this).select();
-  });
-
-  if(jumpToTime !== null) {
-    jQuery('div.point').each(function (index) {
-      if (parseInt(jQuery(this).find('a.indexJumpLink').data('timestamp')) == jumpToTime) {
-        jumpLink = jQuery(this).find('a.indexJumpLink');
-        jQuery('#accordionHolder').accordion({active: index});
-        jQuery('#accordionHolder-alt').accordion({active: index});
-        var interval = setInterval(function() {
-          <?php
-switch ($interview->playername) {
-    case 'youtube': ?>
-          if (player !== undefined &&
-            player.getCurrentTime !== undefined && player.getCurrentTime() == jumpToTime) {
-          <?php
-        break;
-    case 'brightcove': ?>
-          if (modVP !== undefined &&
-            modVP.getVideoPosition !== undefined &&
-            Math.floor(modVP.getVideoPosition(false)) == jumpToTime) {
-          <?php
-        break;
-    case 'kaltura': ?>
-          if (kdp !== undefined && kdp.evaluate('{video.player.currentTime}') == jumpToTime) {
-          <?php
-        break;
-    default: ?>
-          if(Math.floor(jQuery('#subjectPlayer').data('jPlayer').status.currentTime) == jumpToTime) {
-          <?php
-        break;
-} ?>
-            clearInterval(interval);
-          } else {
-            jumpLink.click();
-          }
-        }, 500);
-        jQuery(this).find('a.indexJumpLink').click();
-      }
-    });
-  }
-
-  $(".fancybox").fancybox();
-  $(".various").fancybox({
-    maxWidth    : 800,
-    maxHeight   : 600,
-    fitToView   : false,
-    width       : '70%',
-    height      : '70%',
-    autoSize    : false,
-    closeClick  : false,
-    openEffect  : 'none',
-    closeEffect : 'none'
-  });
-  $('.fancybox-media').fancybox({
-    openEffect  : 'none',
-    closeEffect : 'none',
-    width       : '80%',
-    height      : '80%',
-    fitToView   : true,
-    helpers     : {
-      media : {}
-    }
-  });
-  $(".fancybox-button").fancybox({
-    prevEffect : 'none',
-    nextEffect : 'none',
-    closeBtn   : false,
-    helpers    : {
-      title   : { type : 'inside' },
-      buttons : {}
-    }
-  });
-
-  jQuery('#lnkRights').click(function() {
-    jQuery('#rightsStatement').fadeToggle(400);
-    return false;
-  });
-
-  jQuery('#lnkUsage').click(function() {
-    jQuery('#usageStatement').fadeToggle(400);
-    return false;
-  });
-});
-</script>
-<script type="text/javascript">
-var cachefile = '<?php echo $interview->cachefile; ?>';
-</script>
-<?php include 'parts/ga.tmpl.php'; ?>
-  </body>
+					$(".fancybox").fancybox();
+					$(".various").fancybox({
+						maxWidth    : 800,
+						maxHeight   : 600,
+						fitToView   : false,
+						width       : '70%',
+						height      : '70%',
+						autoSize    : false,
+						closeClick  : false,
+						openEffect  : 'none',
+						closeEffect : 'none'
+					});
+					$('.fancybox-media').fancybox({
+						openEffect  : 'none',
+						closeEffect : 'none',
+						width       : '80%',
+						height      : '80%',
+						fitToView   : true,
+						helpers     : {
+							media : {}
+						}
+					});
+					$(".fancybox-button").fancybox({
+						prevEffect : 'none',
+						nextEffect : 'none',
+						closeBtn   : false,
+						helpers    : {
+							title   : { type : 'inside' },
+							buttons : {}
+						}
+					});
+					jQuery('#lnkRights').click(function() {
+					jQuery('#rightsStatement').fadeToggle(400);
+							return false;
+					});
+					jQuery('#lnkUsage').click(function() {
+						jQuery('#usageStatement').fadeToggle(400);
+						return false;
+					});
+				});
+			</script>
+		<?php include 'parts/ga.tmpl.php'; ?>
+	</body>
 </html>

--- a/tmpl/viewer.tmpl.php
+++ b/tmpl/viewer.tmpl.php
@@ -71,86 +71,87 @@ $lang = (string) $interview->translate;
 		<?php include 'parts/og.tmpl.php'; ?>
 	</head>
 	<body>
-		<?php if (in_array(substr(strtolower($filepath), -4, 4), $audioFormats)) { ?>
-			<div id="header">
-			<?php } else { ?>
-				<div id="headervid">
-				<?php } ?>
-				<?php if (isset($config[$interview->repository])): ?>
-					<img id="headerimg"
-						 src="<?php echo $config[$interview->repository]['footerimg']; ?>"
-						 alt="<?php echo $config[$interview->repository]['footerimgalt']; ?>" />
-						 <?php endif;
-					 ?>
-				<div class="center">
-					<h1><?php echo $interview->title; ?></h1>
-					<h2 id="secondaryMetaData">
-						<div>
-							<strong><?php echo $interview->repository; ?></strong><br />
-							<?php echo $interview->interviewer; ?>, Interviewer |
-							<?php echo $interview->accession; ?><br />
-							<?php if (isset($interview->collection_link) && (string) $interview->collection_link != '') { ?>
-								<a href="<?php echo $interview->collection_link ?>"><?php echo $interview->collection ?></a> |
-								<?php } else { ?>
-								<?php echo $interview->collection; ?> |
-								<?php } ?>
-							<?php if (isset($interview->series_link) && (string) $interview->series_link != '') { ?>
-								<a href="<?php echo $interview->series_link ?>"><?php echo $interview->series ?></a>
-								<?php } else { ?>
-								<?php echo $interview->series; ?>
-								<?php } ?>
-						</div>
-					</h2>
-					<div id="audio-panel">
-						<?php include_once 'tmpl/player_' . $interview->playername . '.tmpl.php'; ?>
+		
+		<?php $class = in_array(substr(strtolower($filepath), -4, 4), $audioFormats) ? "header" : "headervid"; ?>
+		<div id="<?php echo $class; ?>">				
+			<?php if (isset($config[$interview->repository])): ?>
+				<img id="headerimg" src="<?php echo $config[$interview->repository]['footerimg']; ?>" alt="<?php echo $config[$interview->repository]['footerimgalt']; ?>" />
+			<?php endif; ?>
+			<div class="center">
+				<h1><?php echo $interview->title; ?></h1>
+				<h2 id="secondaryMetaData">
+					<div>
+						<strong><?php echo $interview->repository; ?></strong><br />
+						<?php echo $interview->interviewer; ?>, Interviewer | <?php echo $interview->accession; ?><br />
+						<?php if (isset($interview->collection_link) && (string) $interview->collection_link != '') { ?>
+							<a href="<?php echo $interview->collection_link ?>"><?php echo $interview->collection ?></a> |
+						<?php } else { ?>
+							<?php echo $interview->collection; ?> |
+						<?php } ?>
+
+						<?php if (isset($interview->series_link) && (string) $interview->series_link != '') { ?>
+							<a href="<?php echo $interview->series_link ?>"><?php echo $interview->series ?></a>
+						<?php } else { ?>
+							<?php echo $interview->series; ?>
+						<?php } ?>
+					</div>
+				</h2>
+				<div id="audio-panel">
+					<?php include_once 'tmpl/player_' . $interview->playername . '.tmpl.php'; ?>
+				</div>
+			</div>			
+		</div>
+		
+		<div id="main">
+			<div id="main-panels">
+				<div id="content-panel">
+					<div id="holder-panel"></div>
+					<div id="transcript-panel" class="transcript-panel">
+						<?php echo $interview->transcript; ?>
+					</div>
+					<div id="index-panel" class="index-panel">
+						<?php echo $interview->index; ?>
 					</div>
 				</div>
+				<div id="searchbox-panel"><?php include_once 'tmpl/search.tmpl.php'; ?></div>
 			</div>
-			<div id="main">
-				<div id="main-panels">
-					<div id="content-panel">
-						<div id="holder-panel"></div>
-						<div id="transcript-panel" class="transcript-panel">
-							<?php echo $interview->transcript; ?>
-						</div>
-						<div id="index-panel" class="index-panel">
-							<?php echo $interview->index; ?>
-						</div>
-					</div>
-					<div id="searchbox-panel"><?php include_once 'tmpl/search.tmpl.php'; ?></div>
-				</div>
+		</div>
+		
+		<div id="footer">
+			<div id="footer-metadata">
+				
+				<?php if (!empty($rights)) { ?>
+					<h3><a href="#" id="lnkRights">View Rights Statement</a></h3>
+					<div id="rightsStatement"><p><?php echo $rights; ?></p></div>
+				<?php } else { ?>
+					<h3>No Rights Statement</h3>
+				<?php }	?>
+					
+				<?php if (!empty($usage)) { ?>
+					<h3><a href="#" id="lnkUsage">View Usage Statement</a></h3>
+					<div id="usageStatement"><p><?php echo $usage; ?></p></div>
+				<?php } else { ?>
+					<h3>No Usage Statement</h3>
+				<?php }	?>
+					
+				<?php if (!empty($collectionLink)) { ?>
+					<h3>Collection Link: <a	href="<?php echo $interview->collection_link ?>"><?php echo $interview->collection ?></a></h3>
+				<?php }	?>
+					
+				<?php if (!empty($seriesLink)) { ?>
+					<h3>Series Link: <a href="<?php echo $interview->series_link ?>"><?php echo $interview->series ?></a></h3>
+				<?php }	?>
+					
+				<h3>Contact Us: <a href="mailto:<?php echo $contactemail ?>"><?php echo $contactemail ?></a> | <a href="<?php echo $contactlink ?>"><?php echo $contactlink ?></a></h3>
 			</div>
-			<div id="footer">
-				<div id="footer-metadata">
-					<?php if (!empty($rights)) { ?>
-						<p><span><h3><a href="#" id="lnkRights">View Rights Statement</a></h3>
-								<div id="rightsStatement"><?php echo $rights; ?></div></span></p>
-						<?php } else { ?>
-						<p><span><h3>View Rights Statement</h3></span></p>
-						<?php }	?>
-					<?php if (!empty($usage)) { ?>
-						<p><span><h3><a href="#" id="lnkUsage">View Usage Statement</a></h3>
-								<div id="usageStatement"><?php echo $usage; ?></div></span></p>
-						<?php } else { ?>
-						<p><span><h3>View Usage Statement</h3></span></p>
-						<?php }	?>
-					<?php if (!empty($collectionLink)) { ?>
-						<p><span><h3> Collection Link: <a	href="<?php echo $interview->collection_link ?>"><?php echo $interview->collection ?></a></h3></span></p>
-							<?php }	?>
-						<?php if (!empty($seriesLink)) { ?>
-						<p><span><h3>Series Link: <a href="<?php echo $interview->series_link ?>"><?php echo $interview->series ?></a></h3></span></p>
-							<?php }	?>
-					<p><span><h3>Contact Us: <a href="mailto:<?php echo $contactemail ?>"><?php echo $contactemail ?></a> |
-								<a href="<?php echo $contactlink ?>"><?php echo $contactlink ?></a></h3></span></p>
-				</div>
-				<div id="footer-copyright">
-					<small id="copyright"><span>&copy; <?php echo Date("Y") ?></span><?php echo $copyrightholder ?></small>
-				</div>
-				<div id="footer-logo">
-					<img alt="Powered by OHMS logo" src="imgs/ohms_logo.png" border="0"/>
-				</div>
-				<br clear="both" />
+			<div id="footer-copyright">
+				<small id="copyright">&copy; <?php echo Date("Y") ?> <?php echo $copyrightholder ?></small>
 			</div>
+			<div id="footer-logo">
+				<img alt="Powered by OHMS logo" src="imgs/ohms_logo.png" border="0"/>
+			</div>
+			<br clear="both" />
+		</div>
 		<?php include 'parts/ga.tmpl.php'; ?>
 	</body>
 </html>

--- a/tmpl/viewer.tmpl.php
+++ b/tmpl/viewer.tmpl.php
@@ -67,16 +67,7 @@ GASCRIPT;
     <script type="text/javascript" src="js/jquery-ui.toggleSwitch.js"></script>
     <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js"></script>
     <script type="text/javascript" src="js/viewer.js"></script>
-    <meta property="og:title" content="<?php echo $interview->title; ?>" />
-    <meta property="og:url" content="<?php echo $baseurl ?>">
-    <?php if (isset($openGraphImage)) { ?>
-    <meta property="og:image" content="<?php echo "$baseurl/$openGraphImage" ?>">
-    <?php
-} ?>
-    <?php if (isset($openGraphDescription)) { ?>
-    <meta property="og:description" content="<?php echo "$openGraphDescription" ?>">
-    <?php
-} ?>
+	<?php include 'parts/og.tmpl.php'; ?>
   </head>
   <body>
 <script type="text/javascript">

--- a/tmpl/viewer.tmpl.php
+++ b/tmpl/viewer.tmpl.php
@@ -34,21 +34,6 @@ if (isset($config[$interview->repository])) {
 $seriesLink = (string)$interview->series_link;
 $collectionLink = (string)$interview->collection_link;
 $lang = (string)$interview->translate;
-
-$gaScript = null;
-if (isset($repoConfig['ga_tracking_id'])) {
-    $gaScript = <<<GASCRIPT
-<script type="text/javascript">
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-ga('create', '{$repoConfig['ga_tracking_id']}', '{$repoConfig['ga_host']}');
-ga('send', 'pageview');
-</script>
-GASCRIPT;
-}
 ?>
 <!DOCTYPE html>
 <html>

--- a/tmpl/viewer.tmpl.php
+++ b/tmpl/viewer.tmpl.php
@@ -116,42 +116,7 @@ $lang = (string) $interview->translate;
 				<div id="searchbox-panel"><?php include_once 'tmpl/search.tmpl.php'; ?></div>
 			</div>
 		</div>
-		
-		<div id="footer">
-			<div id="footer-metadata">
-				
-				<?php if (!empty($rights)) { ?>
-					<h3><a href="#" id="lnkRights">View Rights Statement</a></h3>
-					<div id="rightsStatement"><p><?php echo $rights; ?></p></div>
-				<?php } else { ?>
-					<h3>No Rights Statement</h3>
-				<?php }	?>
-					
-				<?php if (!empty($usage)) { ?>
-					<h3><a href="#" id="lnkUsage">View Usage Statement</a></h3>
-					<div id="usageStatement"><p><?php echo $usage; ?></p></div>
-				<?php } else { ?>
-					<h3>No Usage Statement</h3>
-				<?php }	?>
-					
-				<?php if (!empty($collectionLink)) { ?>
-					<h3>Collection Link: <a	href="<?php echo $interview->collection_link ?>"><?php echo $interview->collection ?></a></h3>
-				<?php }	?>
-					
-				<?php if (!empty($seriesLink)) { ?>
-					<h3>Series Link: <a href="<?php echo $interview->series_link ?>"><?php echo $interview->series ?></a></h3>
-				<?php }	?>
-					
-				<h3>Contact Us: <a href="mailto:<?php echo $contactemail ?>"><?php echo $contactemail ?></a> | <a href="<?php echo $contactlink ?>"><?php echo $contactlink ?></a></h3>
-			</div>
-			<div id="footer-copyright">
-				<small id="copyright">&copy; <?php echo Date("Y") ?> <?php echo $copyrightholder ?></small>
-			</div>
-			<div id="footer-logo">
-				<img alt="Powered by OHMS logo" src="imgs/ohms_logo.png" border="0"/>
-			</div>
-			<br clear="both" />
-		</div>
+		<?php include 'parts/footer.tmpl.php'; ?>
 		<?php include 'parts/ga.tmpl.php'; ?>
 	</body>
 </html>

--- a/tmpl/viewer.tmpl.php
+++ b/tmpl/viewer.tmpl.php
@@ -1,40 +1,4 @@
-<?php
-date_default_timezone_set($config['timezone']);
-$audioFormats = array('.mp3', '.wav', '.ogg', '.flac', '.m4a');
-$filepath = $interview->media_url;
-$rights = (string) $interview->rights;
-$usage = (string) $interview->usage;
-$contactemail = '';
-$contactlink = '';
-$copyrightholder = '';
-$protocol = 'https';
-if (!isset($_SERVER['HTTPS']) || $_SERVER['HTTPS'] != 'on') {
-	$protocol = 'http';
-}
-$host = $_SERVER['HTTP_HOST'];
-$uri = $_SERVER['REQUEST_URI'];
-$baseurl = "$protocol://$host$uri";
-$extraCss = null;
-if (isset($config[$interview->repository])) {
-	$repoConfig = $config[$interview->repository];
-	$contactemail = $repoConfig['contactemail'];
-	$contactlink = $repoConfig['contactlink'];
-	$copyrightholder = $repoConfig['copyrightholder'];
-	if (isset($repoConfig['open_graph_image']) && $repoConfig['open_graph_image'] <> '') {
-		$openGraphImage = $repoConfig['open_graph_image'];
-	}
-	if (isset($repoConfig['open_graph_description']) && $repoConfig['open_graph_description'] <> '') {
-		$openGraphDescription = $repoConfig['open_graph_description'];
-	}
-
-	if (isset($repoConfig['css']) && strlen($repoConfig['css']) > 0) {
-		$extraCss = $repoConfig['css'];
-	}
-}
-$seriesLink = (string) $interview->series_link;
-$collectionLink = (string) $interview->collection_link;
-$lang = (string) $interview->translate;
-?>
+<?php include 'parts/init.tmpl.php'; ?>
 <!DOCTYPE html>
 <html>
 	<head>
@@ -72,50 +36,7 @@ $lang = (string) $interview->translate;
 	</head>
 	<body>
 		
-		<?php $class = in_array(substr(strtolower($filepath), -4, 4), $audioFormats) ? "header" : "headervid"; ?>
-		<div id="<?php echo $class; ?>">				
-			<?php if (isset($config[$interview->repository])): ?>
-				<img id="headerimg" src="<?php echo $config[$interview->repository]['footerimg']; ?>" alt="<?php echo $config[$interview->repository]['footerimgalt']; ?>" />
-			<?php endif; ?>
-			<div class="center">
-				<h1><?php echo $interview->title; ?></h1>
-				<h2 id="secondaryMetaData">
-					<div>
-						<strong><?php echo $interview->repository; ?></strong><br />
-						<?php echo $interview->interviewer; ?>, Interviewer | <?php echo $interview->accession; ?><br />
-						<?php if (isset($interview->collection_link) && (string) $interview->collection_link != '') { ?>
-							<a href="<?php echo $interview->collection_link ?>"><?php echo $interview->collection ?></a> |
-						<?php } else { ?>
-							<?php echo $interview->collection; ?> |
-						<?php } ?>
-
-						<?php if (isset($interview->series_link) && (string) $interview->series_link != '') { ?>
-							<a href="<?php echo $interview->series_link ?>"><?php echo $interview->series ?></a>
-						<?php } else { ?>
-							<?php echo $interview->series; ?>
-						<?php } ?>
-					</div>
-				</h2>
-				<div id="audio-panel">
-					<?php include_once 'tmpl/player_' . $interview->playername . '.tmpl.php'; ?>
-				</div>
-			</div>			
-		</div>
-		
-		<div id="main">
-			<div id="main-panels">
-				<div id="content-panel">
-					<div id="holder-panel"></div>
-					<div id="transcript-panel" class="transcript-panel">
-						<?php echo $interview->transcript; ?>
-					</div>
-					<div id="index-panel" class="index-panel">
-						<?php echo $interview->index; ?>
-					</div>
-				</div>
-				<div id="searchbox-panel"><?php include_once 'tmpl/search.tmpl.php'; ?></div>
-			</div>
-		</div>
+		<?php include 'parts/main.tmpl.php'; ?>
 		<?php include 'parts/footer.tmpl.php'; ?>
 		<?php include 'parts/ga.tmpl.php'; ?>
 	</body>

--- a/tmpl/viewer.tmpl.php
+++ b/tmpl/viewer.tmpl.php
@@ -67,6 +67,18 @@ GASCRIPT;
     <script type="text/javascript" src="js/jquery-ui.toggleSwitch.js"></script>
     <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js"></script>
     <script type="text/javascript" src="js/viewer.js"></script>
+	<script type="text/javascript" src="js/jquery.jplayer.min.js"></script>
+	<script type="text/javascript" src="js/jquery.easing.1.3.js"></script>
+	<script type="text/javascript" src="js/jquery.scrollTo-min.js"></script>
+	<script type="text/javascript" src="js/viewer_<?php echo  $interview->viewerjs;?>.js"></script>
+	<link rel="stylesheet" href="js/fancybox_2_1_5/source/jquery.fancybox.css?v=2.1.5" type="text/css" media="screen" />
+	<link rel="stylesheet" href="skin/jplayer.blue.monday.css" type="text/css" media="screen" />
+	<script type="text/javascript" src="js/fancybox_2_1_5/source/jquery.fancybox.pack.js?v=2.1.5"></script>
+	<link rel="stylesheet" href="js/fancybox_2_1_5/source/helpers/jquery.fancybox-buttons.css?v=1.0.5" type="text/css" media="screen" />
+	<script type="text/javascript" src="js/fancybox_2_1_5/source/helpers/jquery.fancybox-buttons.js?v=1.0.5"></script>
+	<script type="text/javascript" src="js/fancybox_2_1_5/source/helpers/jquery.fancybox-media.js?v=1.0.6"></script>
+	<link rel="stylesheet" href="js/fancybox_2_1_5/source/helpers/jquery.fancybox-thumbs.css?v=1.0.7" type="text/css" media="screen" />
+	<script type="text/javascript" src="js/fancybox_2_1_5/source/helpers/jquery.fancybox-thumbs.js?v=1.0.7"></script>
 	<?php include 'parts/og.tmpl.php'; ?>
   </head>
   <body>
@@ -173,20 +185,6 @@ endif; ?>
         </div>
         <br clear="both" />
       </div>
-<script type="text/javascript" src="js/jquery.jplayer.min.js"></script>
-<script type="text/javascript" src="js/jquery.easing.1.3.js"></script>
-<script type="text/javascript" src="js/jquery.scrollTo-min.js"></script>
-<script type="text/javascript" src="js/viewer_<?php echo  $interview->viewerjs;?>.js"></script>
-<link rel="stylesheet" href="js/fancybox_2_1_5/source/jquery.fancybox.css?v=2.1.5" type="text/css" media="screen" />
-<link rel="stylesheet" href="skin/jplayer.blue.monday.css" type="text/css" media="screen" />
-<script type="text/javascript" src="js/fancybox_2_1_5/source/jquery.fancybox.pack.js?v=2.1.5"></script>
-<link rel="stylesheet"
-      href="js/fancybox_2_1_5/source/helpers/jquery.fancybox-buttons.css?v=1.0.5" type="text/css" media="screen" />
-<script type="text/javascript" src="js/fancybox_2_1_5/source/helpers/jquery.fancybox-buttons.js?v=1.0.5"></script>
-<script type="text/javascript" src="js/fancybox_2_1_5/source/helpers/jquery.fancybox-media.js?v=1.0.6"></script>
-<link rel="stylesheet"
-      href="js/fancybox_2_1_5/source/helpers/jquery.fancybox-thumbs.css?v=1.0.7" type="text/css" media="screen" />
-<script type="text/javascript" src="js/fancybox_2_1_5/source/helpers/jquery.fancybox-thumbs.js?v=1.0.7"></script>
 <script type="text/javascript">
 $(document).ready(function() {
   jQuery('a.indexSegmentLink').on('click', function (e) {

--- a/tmpl/viewer.tmpl.php
+++ b/tmpl/viewer.tmpl.php
@@ -50,11 +50,9 @@ $lang = (string) $interview->translate;
 		<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
 		<script type="text/javascript" src="js/jquery-ui.toggleSwitch.js"></script>
 		<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js"></script>
-		<script type="text/javascript" src="js/viewer.js"></script>
 		<script type="text/javascript" src="js/jquery.jplayer.min.js"></script>
 		<script type="text/javascript" src="js/jquery.easing.1.3.js"></script>
 		<script type="text/javascript" src="js/jquery.scrollTo-min.js"></script>
-		<script type="text/javascript" src="js/viewer_<?php echo $interview->viewerjs; ?>.js"></script>
 		<link rel="stylesheet" href="js/fancybox_2_1_5/source/jquery.fancybox.css?v=2.1.5" type="text/css" media="screen" />
 		<link rel="stylesheet" href="skin/jplayer.blue.monday.css" type="text/css" media="screen" />
 		<script type="text/javascript" src="js/fancybox_2_1_5/source/jquery.fancybox.pack.js?v=2.1.5"></script>
@@ -63,6 +61,13 @@ $lang = (string) $interview->translate;
 		<script type="text/javascript" src="js/fancybox_2_1_5/source/helpers/jquery.fancybox-media.js?v=1.0.6"></script>
 		<link rel="stylesheet" href="js/fancybox_2_1_5/source/helpers/jquery.fancybox-thumbs.css?v=1.0.7" type="text/css" media="screen" />
 		<script type="text/javascript" src="js/fancybox_2_1_5/source/helpers/jquery.fancybox-thumbs.js?v=1.0.7"></script>
+		<script type="text/javascript" src="js/viewer.js"></script>
+		<script type="text/javascript" src="js/viewer_<?php echo $interview->viewerjs; ?>.js"></script>
+		<script type="text/javascript">				
+			var cachefile = '<?php echo $interview->cachefile; ?>';
+			var playerName = '<?php echo $interview->playername; ?>';
+		</script>
+		<script type="text/javascript" src="js/viewer_init.js"></script>
 		<?php include 'parts/og.tmpl.php'; ?>
 	</head>
 	<body>
@@ -146,117 +151,6 @@ $lang = (string) $interview->translate;
 				</div>
 				<br clear="both" />
 			</div>
-			<script type="text/javascript">				
-				var cachefile = '<?php echo $interview->cachefile; ?>';
-				var playerName = '<?php echo $interview->playername; ?>';
-				console.log(playerName);
-				var jumpToTime = null;
-				if (location.href.search('#segment') > -1) {
-					var jumpToTime = parseInt(location.href.replace(/(.*)#segment/i, ""));
-					if (isNaN(jumpToTime)) {
-						jumpToTime = 0;
-					}
-				}
-				
-				$(document).ready(function() {
-
-					jQuery('a.indexSegmentLink').click(function (e) {
-						e.preventDefault();
-						var linkContainer = '#segmentLink' + jQuery(e.target).data('timestamp');
-						if (jQuery(linkContainer).css("display") == "none") {
-							jQuery(linkContainer).fadeIn(1000);
-						} else {
-							jQuery(linkContainer).fadeOut();
-						}
-					});
-					
-					jQuery('.segmentLinkTextBox').on('click', function () {
-						jQuery(this).select();
-					});
-					
-					if (jumpToTime !== null) {
-						jQuery('div.point').each(function (index) {
-							if (parseInt(jQuery(this).find('a.indexJumpLink').data('timestamp')) == jumpToTime) {
-								jumpLink = jQuery(this).find('a.indexJumpLink');
-								jQuery('#accordionHolder').accordion({active: index});
-								jQuery('#accordionHolder-alt').accordion({active: index});
-								var interval = setInterval(function() {
-									var reset = false;
-									switch(playerName) {
-										case 'youtube': 
-											if (player !== undefined && player.getCurrentTime !== undefined && player.getCurrentTime() == jumpToTime) {
-												reset = true;
-											}
-											break;
-										case 'brightcove': 
-											if (modVP !== undefined && modVP.getVideoPosition !== undefined && Math.floor(modVP.getVideoPosition(false)) == jumpToTime) {
-												reset = true;
-											}
-											break;
-										case 'kaltura': 
-											if (kdp !== undefined && kdp.evaluate('{video.player.currentTime}') == jumpToTime) {
-												reset = true;
-											}
-											break;
-										default: 
-											if (Math.floor(jQuery('#subjectPlayer').data('jPlayer').status.currentTime) == jumpToTime) {
-												reset = true;
-											}
-											break;
-									}
-									if(reset) {
-										clearInterval(interval);
-									} else {
-										jumpLink.click();
-									}
-								}, 500);
-								
-								jQuery(this).find('a.indexJumpLink').click();
-							}
-						});
-					}
-
-					$(".fancybox").fancybox();
-					$(".various").fancybox({
-						maxWidth    : 800,
-						maxHeight   : 600,
-						fitToView   : false,
-						width       : '70%',
-						height      : '70%',
-						autoSize    : false,
-						closeClick  : false,
-						openEffect  : 'none',
-						closeEffect : 'none'
-					});
-					$('.fancybox-media').fancybox({
-						openEffect  : 'none',
-						closeEffect : 'none',
-						width       : '80%',
-						height      : '80%',
-						fitToView   : true,
-						helpers     : {
-							media : {}
-						}
-					});
-					$(".fancybox-button").fancybox({
-						prevEffect : 'none',
-						nextEffect : 'none',
-						closeBtn   : false,
-						helpers    : {
-							title   : { type : 'inside' },
-							buttons : {}
-						}
-					});
-					jQuery('#lnkRights').click(function() {
-					jQuery('#rightsStatement').fadeToggle(400);
-							return false;
-					});
-					jQuery('#lnkUsage').click(function() {
-						jQuery('#usageStatement').fadeToggle(400);
-						return false;
-					});
-				});
-			</script>
 		<?php include 'parts/ga.tmpl.php'; ?>
 	</body>
 </html>


### PR DESCRIPTION
In preparation for building and OHMS Solution Pack and Viewer for Islandora, I've had to split the main template in to multiple files (our solution pack viewer won't need to add head and body tags, for example). Along the way I changed a few other things around as well.

 * Improved error handling in the renderer to preset error messages to the user
 * Removed unnecessary code in some PHP files
 * Moved most of the javascript in the main template to its own file, and simplified and reformatted it quite a bit.
 * Moved the open graph and google analytics code to separate files
 * Moved the script and link tags into the HTML head element
 * Reformatted the HTML in the template to be valid
 * Moved the footer and initialization code into separate files
 * And finally, I added support for different views to the ViewerController.

I realize this is a big change, but hopefully it's more readable, maintainable, and more flexible. 