### PR TITLE
Added processing of $_REQUEST['cachefile'] with basename().

### DIFF
--- a/index.php
+++ b/index.php
@@ -12,8 +12,9 @@ if (!isset($_GET['translate'])) {
 if (isset($_REQUEST['cachefile'])) {
     $kw = (isset($_REQUEST['kw'])) ? $_REQUEST['kw'] : null;
     $action = (isset($_REQUEST['action'])) ? $_REQUEST['action'] : null;
-    $vController = new ViewerController($_REQUEST['cachefile']);
-    $vController->route($action, $kw, $_REQUEST['cachefile']);
+    $cachefile = basename($_REQUEST['cachefile']);
+    $vController = new ViewerController($cachefile);
+    $vController->route($action, $kw, $cachefile);
 } else {
     header('HTTP/1.0 404 Not Found');
     //echo 'Error no action to take.';

--- a/render.php
+++ b/render.php
@@ -12,8 +12,9 @@ if (!isset($_GET['translate'])) {
 if (isset($_REQUEST['cachefile'])) {
     $kw = (isset($_REQUEST['kw'])) ? $_REQUEST['kw'] : null;
     $action = (isset($_REQUEST['action'])) ? $_REQUEST['action'] : null;
-    $vController = new ViewerController($_REQUEST['cachefile']);
-    $vController->route($action, $kw, $_REQUEST['cachefile']);
+    $cachefile = basename($_REQUEST['cachefile']);
+    $vController = new ViewerController($cachefile);
+    $vController->route($action, $kw, $cachefile);
 } else {
     header('HTTP/1.0 404 Not Found');
     //echo 'Error no action to take.';

--- a/viewer.php
+++ b/viewer.php
@@ -12,8 +12,9 @@ if (!isset($_GET['translate'])) {
 if (isset($_REQUEST['cachefile'])) {
     $kw = (isset($_REQUEST['kw'])) ? $_REQUEST['kw'] : null;
     $action = (isset($_REQUEST['action'])) ? $_REQUEST['action'] : null;
-    $vController = new ViewerController($_REQUEST['cachefile']);
-    $vController->route($action, $kw, $_REQUEST['cachefile']);
+    $cachefile = basename($_REQUEST['cachefile']);
+    $vController = new ViewerController($cachefile);
+    $vController->route($action, $kw, $cachefile);
 } else {
     header('HTTP/1.0 404 Not Found');
     //echo 'Error no action to take.';


### PR DESCRIPTION
This prevents values like '../../path/to/file.xml' being passed on, which can
be resolved outside of the configured directory by file_get_contents().

(In practice I can't see this could ever be used to retrieve meaningful information using the viewer as-is, since reading any file which doesn't match the expected format will fail in the relevant cachefile constructor.)