### PR TITLE
Corrected order of constructor variables in creation of Legacy cache file.

### DIFF
--- a/app/Ohms/Interview/Legacy.php
+++ b/app/Ohms/Interview/Legacy.php
@@ -124,7 +124,7 @@ class Legacy
     public static function getInstance($viewerconfig, $tmpDir, $cachefile = null)
     {
         if (!self::$Instance) {
-            self::$Instance = new Legacy($cachefile, $tmpDir, $viewerconfig);
+            self::$Instance = new Legacy($viewerconfig, $tmpDir, $cachefile);
         }
         return self::$Instance;
     }


### PR DESCRIPTION
This fixes a bug introduced in commit 3f6f35d, when the order of the constructor parameters was altered.