### PR TITLE
Fix to iconv() call that drops UTF-8 characters from the transcript.

### DIFF
--- a/app/Ohms/Transcript.php
+++ b/app/Ohms/Transcript.php
@@ -196,7 +196,7 @@ POINT;
         if (strtolower($this->language) == 'arabic')
             $this->transcriptHTML = $this->transcript;
         else
-            $this->transcriptHTML = iconv("UTF-8", "ASCII//IGNORE", $this->transcript);
+            $this->transcriptHTML = iconv("UTF-8", "UTF-8//IGNORE", $this->transcript);
         
         if (strlen($this->transcriptHTML) == 0) {
             return;


### PR DESCRIPTION
ohms-viewer currently drops all non-ASCII characters from XML transcripts losing all accented characters and other UTF-8 valid input.  This seems to be caused by this call to iconv(), its possible that this entire line can be dropped but I figured it was safer to suggest a minimal change that drops non-UTF-8 from the input.