### PR TITLE
Fix HTTPS detection on Kaltura player template

### DIFF
--- a/tmpl/player_kaltura.tmpl.php
+++ b/tmpl/player_kaltura.tmpl.php
@@ -22,10 +22,10 @@ preg_match("{https?\://[^/]+}", $embedcode, $matches);
 $kalturaHost = $matches[0];
 
 # XXX: This block requires further attention.
-if ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443) {
+if ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443 || !empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' || !empty($_SERVER['HTTP_X_FORWARDED_SSL']) && $_SERVER['HTTP_X_FORWARDED_SSL'] == 'on') {
     $kalturaHost = str_replace('http:', 'https:', $kalturaHost);
 } else {
-    $kalturaHost = str_replace('https:', 'http:', $kalturaHost);
+i #   $kalturaHost = str_replace('https:', 'http:', $kalturaHost); # No need for this to be modified actually. 
 }
 
 $height = ($interview->clip_format == 'audio' ? 95 : 279);

--- a/tmpl/player_kaltura.tmpl.php
+++ b/tmpl/player_kaltura.tmpl.php
@@ -22,10 +22,10 @@ preg_match("{https?\://[^/]+}", $embedcode, $matches);
 $kalturaHost = $matches[0];
 
 # XXX: This block requires further attention.
+# XXX: Detect if HTTPS either behind proxy or not. Only change if OHMS-Viewer is HTTPS
+# XXX:  Browsers don't care if you make an HTTPS request from an HTTP page
 if ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443 || !empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' || !empty($_SERVER['HTTP_X_FORWARDED_SSL']) && $_SERVER['HTTP_X_FORWARDED_SSL'] == 'on') {
     $kalturaHost = str_replace('http:', 'https:', $kalturaHost);
-} else {
- #   $kalturaHost = str_replace('https:', 'http:', $kalturaHost); # No need for this to be modified actually. 
 }
 
 $height = ($interview->clip_format == 'audio' ? 95 : 279);

--- a/tmpl/player_kaltura.tmpl.php
+++ b/tmpl/player_kaltura.tmpl.php
@@ -25,7 +25,7 @@ $kalturaHost = $matches[0];
 if ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443 || !empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' || !empty($_SERVER['HTTP_X_FORWARDED_SSL']) && $_SERVER['HTTP_X_FORWARDED_SSL'] == 'on') {
     $kalturaHost = str_replace('http:', 'https:', $kalturaHost);
 } else {
-i #   $kalturaHost = str_replace('https:', 'http:', $kalturaHost); # No need for this to be modified actually. 
+ #   $kalturaHost = str_replace('https:', 'http:', $kalturaHost); # No need for this to be modified actually. 
 }
 
 $height = ($interview->clip_format == 'audio' ? 95 : 279);


### PR DESCRIPTION
The Kaltura player template incorrectly assumes that if SSL is off  or the server port isn't 443 than the page is not HTTPS.   This ignores the situations in which OHMS-Viewer is behind a proxy that handles HTTPS offloading. 

Additionally, there is no need to change the HTTP protocol (and furthermore, likely not desired) when the OHMS-Viewer is HTTP and the content is HTTPS. Browsers should only complain when it's HTTP content referenced on an HTTPS page.


The combination of the two issues causes the viewer to change the content type erroneously when it thinks the viewer application isn't HTTPS. This causes browsers to block the insecure content and display a blank area. 


I did not check if this type of detection is used elsewhere so this may be better positioned in a method elsewhere and referenced as such here. 


